### PR TITLE
Fix/refactor find_missing_base(), add .gititnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/R/qc_funs_base.R
+++ b/R/qc_funs_base.R
@@ -15,29 +15,38 @@ find_duplicates_base <- function(df){
 
 find_missing_base <- function(df, lipids = c('13:0', '16:0', '19:0')){
 
-  data_files <- unique(df$DataFileName)
-  all_lipids <- lipid_reference['fame']
-
+  data_files <- unique(df$DataFileName)  # list of all sample fnames in batch
+  # '_' to avoid conflict btwn df
+  lipids_df <- data.frame(FAME = lipids, Batch_ = df[['Batch']][1])
+  # loop through each sample (filename) to create df of missing lipids
   tmp_list <- lapply(data_files,
-    function(x){
-      tmp <- merge(all_lipids, df[df[['DataFileName']] == x, ], by.x = 'fame',
-            by.y = 'Name', all.x = TRUE)
-      tmp[is.na(tmp[['DataFileName']]), 'DataFileName'] <-  #Would like to find a more elegant solution for filling missing values
-        tmp[!is.na(tmp[['DataFileName']]), 'DataFileName'][[1]]
-      tmp[is.na(tmp[['Batch']]), 'Batch'] <-
-        tmp[!is.na(tmp[['Batch']]), 'Batch'][[1]]
-      tmp[is.na(tmp[['TotalPeakArea1']]) & tmp[['fame']] %in% lipids, ]
-    }
+                     function(x){
+                       # for each samp left join named peaks to col of all microbe lipids
+                       # if lipid absent from sample, all fields for FAME are NA
+                       tmp <- merge(lipids_df, df[df[['DataFileName']] == x, ], by.x = 'FAME',
+                                    by.y = 'Name', all.x = TRUE)
+
+                       # fill NA DataFileName cols - uses first NA val (all are the same)
+                       tmp[is.na(tmp[['DataFileName']]), 'DataFileName'] <- x
+
+                       # select rows for lipids missing from sample and in list of std lipids
+                       tmp[is.na(tmp[['TotalPeakArea1']]), ]
+
+                     }
   )
+
+  # combine list to df showing all sample/lipid combos missing
   missing_std_df <- do.call('rbind', tmp_list)
 
+  # print warning if standards were missing from any samps (user can check)
   if(nrow(missing_std_df) > 0){
-    cat('Warning: Standards missing from at least one sample.\n')
-    cat('Check data file and/or chromatograms before proceeding\n\n')
+    message(paste0('Warning: Standards missing from at least one sample.\n',
+                   'Check data file and/or chromatograms before proceeding\n\n')
+    )
     #cat(missing_std_df[which(missing_std_df[['Count']] > 1),][['DataFileName']])
   }
 
-  return(missing_std_df[c('Batch', 'DataFileName', 'fame')])
+  return(missing_std_df[c('Batch_', 'DataFileName', 'FAME')])
 
 }
 


### PR DESCRIPTION
Reverted to previous commit, since I accidentally added example scripts
to the project folder, so they would run each time I rebuilt. Couldn't
get rid of them, even with deleting or relocating. Fixed issue in
find_missing_base() which caused error if samples contained no microbial
lipids. Fix also simplified code.